### PR TITLE
systemd: restart on failure

### DIFF
--- a/ftl.service
+++ b/ftl.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 RuntimeDirectory=pihole
 ExecStart=/usr/bin/pihole-ftl -f -- -C /etc/pihole/dnsmasq.conf
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When used as DNS proxy, ftl should be restarted by systemd if a crash
occurs.

NethServer/dev#6212